### PR TITLE
相対位置入力の実装

### DIFF
--- a/BIDSSMemLib.CtrlIOpp/dllmain.cpp
+++ b/BIDSSMemLib.CtrlIOpp/dllmain.cpp
@@ -19,19 +19,19 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
 HANDLE MMFCtrlHHandle = NULL;
 HANDLE MMFCtrlKHandle = NULL;
-Hand* MMFViewHHandle = NULL;
+Hands* MMFViewHHandle = NULL;
 KeyD* MMFViewKHandle = NULL;
-const Hand brankhd;
+const Hands brankhd;
 const KeyD brankkd;
 void Initialize(const char* MMFCtrlKName, const char* MMFCtrlHName) {
 	MMFCtrlHHandle = OpenFileMapping(FILE_MAP_ALL_ACCESS, false, (LPCSTR)MMFCtrlHName);
 	if (MMFCtrlHHandle == NULL)
-		MMFCtrlHHandle = CreateFileMapping((HANDLE)0xFFFFFFFF, NULL, PAGE_READWRITE, 0, sizeof(Hand), (LPCSTR)MMFCtrlHName);
+		MMFCtrlHHandle = CreateFileMapping((HANDLE)0xFFFFFFFF, NULL, PAGE_READWRITE, 0, sizeof(Hands), (LPCSTR)MMFCtrlHName);
 	MMFCtrlKHandle = OpenFileMapping(FILE_MAP_ALL_ACCESS, false, (LPCSTR)MMFCtrlKName);
 	if (MMFCtrlKHandle == NULL)
 		MMFCtrlKHandle = CreateFileMapping((HANDLE)0xFFFFFFFF, NULL, PAGE_READWRITE, 0, sizeof(KeyD), (LPCSTR)MMFCtrlKName);
 
-	if (MMFCtrlHHandle != NULL) MMFViewHHandle = (Hand*)MapViewOfFile(MMFCtrlHHandle, SECTION_MAP_READ, 0, 0, 0);
+	if (MMFCtrlHHandle != NULL) MMFViewHHandle = (Hands*)MapViewOfFile(MMFCtrlHHandle, SECTION_MAP_READ, 0, 0, 0);
 	else
 	{
 		MessageBox(NULL, (LPCSTR)L"Could not open the Memory Mapped File of HandD.", (LPCSTR)L"BIDSSMemLib Ctrl Reader", 0);
@@ -43,8 +43,8 @@ void Initialize(const char* MMFCtrlKName, const char* MMFCtrlHName) {
 	}
 }
 
-Hand GetHandD() {
-	if (MMFViewHHandle != NULL) return (Hand)(*MMFViewHHandle);
+Hands GetHandD() {
+	if (MMFViewHHandle != NULL) return (Hands)(*MMFViewHHandle);
 	else return brankhd;
 }
 /*

--- a/BIDSSMemLib.CtrlIOpp/framework.h
+++ b/BIDSSMemLib.CtrlIOpp/framework.h
@@ -6,10 +6,19 @@
 #define KEY_ARRMAXINDEX 128
 struct Hand
 {
-	int P;
 	int B;
+	int P;
 	int R;
 	int C;
+};
+struct Hands
+{
+	int B;
+	int P;
+	int R;
+	int S;
+	double BPos;
+	double PPos;
 };
 struct KeyD
 {
@@ -18,7 +27,7 @@ struct KeyD
 extern "C"
 {
 	__declspec(dllexport) void Initialize(const char*, const char*);
-	__declspec(dllexport) Hand GetHandD();
+	__declspec(dllexport) Hands GetHandD();
 	__declspec(dllexport) KeyD* GetKeyD();
 	__declspec(dllexport) void Dispose();
 }

--- a/BIDSSMemLib/CtrlInput.cs
+++ b/BIDSSMemLib/CtrlInput.cs
@@ -20,7 +20,7 @@ namespace TR.BIDSSMemLib
     [DllImport(CtrlIO_FName)]
     static extern void Initialize(string MMFCtrlKName, string MMFCtrlHName);
     [DllImport(CtrlIO_FName, EntryPoint = "GetHandD")]
-    static extern Hand ppGetHandD();
+    static extern Hands ppGetHandD();
     [DllImport(CtrlIO_FName, EntryPoint = "GetKeyD")]
     static extern IntPtr ppGetKeyD();
     [DllImport(CtrlIO_FName, EntryPoint = "Dispose")]
@@ -33,12 +33,12 @@ namespace TR.BIDSSMemLib
     public CtrlInput()
     {
       MMFCtrlK = MemoryMappedFile.CreateOrOpen(MMFCtrlKName, KeyArrSizeMax * sizeof(bool));
-      MMFCtrlH = MemoryMappedFile.CreateOrOpen(MMFCtrlHName, Marshal.SizeOf(new Hand()));
+      MMFCtrlH = MemoryMappedFile.CreateOrOpen(MMFCtrlHName, Marshal.SizeOf(new Hands()));
     }
 #endif
     public enum HandType
     {
-      Reverser, Power, Brake
+      Reverser, Power, Brake, SelfB, PPos, BPos
     }
 
 #if !CONTROLLER
@@ -168,10 +168,10 @@ namespace TR.BIDSSMemLib
     }
     /// <summary>ハンドル位置指令状態を取得する</summary>
     /// <returns>ハンドル位置指令状態</returns>
-    public Hand GetHandD()
+    public Hands GetHandD()
     {
       //ctr++;
-      Hand hd = new Hand();
+      Hands hd = new Hands();
 #if bve5id
       hd = ppGetHandD();
       //if ((ctr %= 100) == 0)
@@ -197,10 +197,10 @@ namespace TR.BIDSSMemLib
     }
     /// <summary>ハンドル位置指令状態を取得する</summary>
     /// <param name="hd">ハンドル位置指令状態</param>
-    public void GetHandD(ref Hand hd) => hd = GetHandD();
+    public void GetHandD(ref Hands hd) => hd = GetHandD();
     /// <summary>ハンドル位置を設定する</summary>
     /// <param name="hd">指定するハンドル位置</param>
-    public void SetHandD(ref Hand hd)
+    public void SetHandD(ref Hands hd)
     {
 #if bve5id
 
@@ -221,7 +221,7 @@ namespace TR.BIDSSMemLib
 
     public void SetHandD(HandType ht, int value)
     {
-      Hand hd = GetHandD();
+      Hands hd = GetHandD();
       switch (ht)
       {
         case HandType.Brake:
@@ -232,6 +232,35 @@ namespace TR.BIDSSMemLib
           break;
         case HandType.Reverser:
           hd.R = value;
+          break;
+        case HandType.SelfB:
+          hd.S = value;
+          break;
+      }
+      SetHandD(ref hd);
+    }
+    public void SetHandD(HandType ht, double value)
+    {
+      Hands hd = GetHandD();
+      switch (ht)
+      {
+        case HandType.Brake:
+          hd.B = (int)value;
+          break;
+        case HandType.Power:
+          hd.P = (int)value;
+          break;
+        case HandType.Reverser:
+          hd.R = (int)value;
+          break;
+        case HandType.SelfB:
+          hd.S = (int)value;
+          break;
+        case HandType.BPos:
+          hd.BPos = value;
+          break;
+        case HandType.PPos:
+          hd.PPos = value;
           break;
       }
       SetHandD(ref hd);

--- a/BIDSSMemLib/InputDevice.obve.cs
+++ b/BIDSSMemLib/InputDevice.obve.cs
@@ -40,6 +40,12 @@ namespace TR.BIDSSMemLib
 
     public void OnUpdateFrame()
     {
+      Hands hd = new Hands();
+      if (hd.B == 0 && hd.P == 0 && (hd.BPos != 0 || hd.PPos != 0))
+      {
+        hd.P = (int)Math.Round(hd.PPos * HD.P, MidpointRounding.AwayFromZero);
+        hd.B = (int)Math.Round(hd.BPos * HD.B, MidpointRounding.AwayFromZero);
+      }
     }
 
     public void SetElapseData(ElapseData data)

--- a/BIDSSMemLib/SMemLib.struct.cs
+++ b/BIDSSMemLib/SMemLib.struct.cs
@@ -56,6 +56,23 @@ namespace TR.BIDSSMemLib
     /// <summary>定速制御状態</summary>
     public int C;
   };
+  /// <summary>車両のハンドル位置(InputDevice用)</summary>
+  [StructLayout(LayoutKind.Sequential)]
+  public struct Hands
+  {
+    /// <summary>ブレーキハンドル位置</summary>
+    public int B;
+    /// <summary>ノッチハンドル位置</summary>
+    public int P;
+    /// <summary>レバーサーハンドル位置</summary>
+    public int R;
+    /// <summary>自弁ハンドル位置</summary>
+    public int S;
+    /// <summary>制動ハンドル位置(0~1)</summary>
+    public double BPos;
+    /// <summary>力行ハンドル位置(0~1)</summary>
+    public double PPos;
+  };
   /// <summary>BIDSSharedMemoryのデータ構造体</summary>
   [StructLayout(LayoutKind.Sequential)]
   public struct BIDSSharedMemoryData


### PR DESCRIPTION
新規構造体を定義したうえで、double型による相対ハンドル位置入力を実装した。ついでに自弁位置入力にも対応させることができるようにした。

これにより、一部路面電車などに存在する「無段階マスコン」の制作が容易になるほか、デバッグ用コントローラーの作成時にノッチの割り振りを気にする必要がなくなる。