### PR TITLE
Bve6support01

### DIFF
--- a/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
+++ b/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
@@ -47,6 +47,7 @@
     <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -57,6 +58,7 @@
     <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DllExport, PublicKeyToken=8337224c9ad9e356">
@@ -100,9 +102,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) TR.BIDSpp.dll
-copy $(TargetPath) "D:\Users\tetsu\Documents\BveTs\Input Devices\"
-copy $(TargetPath) "D:\Users\tetsu\Documents\BveTs\Scenarios\TR\"</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)$(OutDir)$(TargetFileName)" $(TargetName).$(PlatformName).$(TargetExt)
+copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Input Devices\"
+copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Scenarios\TR\"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <DllExportIdent>50EA9DAE-55C6-4DC8-8192-7B494C39867D</DllExportIdent>

--- a/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
+++ b/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
@@ -8,8 +8,10 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TR.BIDSSMemLib</RootNamespace>
-    <AssemblyName>TR.BIDSSMemLib.bve5</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+		<AssemblyName Condition="'$(Platform)' == 'x86'">TR.BIDSSMemLib.bve5.x86</AssemblyName>
+		<AssemblyName Condition="'$(Platform)' == 'x64'">TR.BIDSSMemLib.bve5.x64</AssemblyName>
+		<TargetFrameworkVersion Condition="'$(Platform)' == 'x86'">v3.5</TargetFrameworkVersion>
+		<TargetFrameworkVersion Condition="'$(Platform)' == 'x64'">v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -17,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UMNGD</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -28,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UMNGD</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -102,11 +104,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)$(OutDir)$(TargetFileName)" $(TargetName).$(PlatformName)$(TargetExt)
-copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Input Devices\"
-copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Scenarios\TR\"</PostBuildEvent>
-  </PropertyGroup>
   <PropertyGroup>
     <DllExportIdent>50EA9DAE-55C6-4DC8-8192-7B494C39867D</DllExportIdent>
     <DllExportMetaLibName>DllExport.dll</DllExportMetaLibName>

--- a/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
+++ b/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
@@ -103,7 +103,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)$(OutDir)$(TargetFileName)" $(TargetName).$(PlatformName).$(TargetExt)
+    <PostBuildEvent>copy "$(ProjectDir)$(OutDir)$(TargetFileName)" $(TargetName).$(PlatformName)$(TargetExt)
 copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Input Devices\"
 copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveTs\Scenarios\TR\"</PostBuildEvent>
   </PropertyGroup>

--- a/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
+++ b/BIDSSMemLib.bve5/BIDSSMemLib.bve5.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TR.BIDSSMemLib</RootNamespace>
     <AssemblyName>TR.BIDSSMemLib.bve5</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;bve5; x86;UMNGD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;bve5; x86;UMNGD</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;bve5; x86;UMNGD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;bve5; x86;UMNGD</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -66,8 +66,9 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Mackoy.IInputDevice">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\mackoy\BveTs5\Mackoy.IInputDevice.DLL</HintPath>
+    <Reference Include="Mackoy.IInputDevice, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\mackoy\BveTs5\Mackoy.IInputDevice.DLL</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -111,7 +112,8 @@ copy "$(ProjectDir)$(OutDir)$(TargetName).$(PlatformName).$(TargetExt)" "D:\BveT
     <DllExportMetaLibName>DllExport.dll</DllExportMetaLibName>
     <DllExportNamespace>TR.BIDSSMemLib</DllExportNamespace>
     <DllExportDDNSCecil>true</DllExportDDNSCecil>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'x86'">x86</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
     <DllExportOrdinalsBase>1</DllExportOrdinalsBase>
     <DllExportGenExpLib>false</DllExportGenExpLib>
     <DllExportOurILAsm>false</DllExportOurILAsm>

--- a/BIDSSMemLib.bve5/Properties/AssemblyInfo.cs
+++ b/BIDSSMemLib.bve5/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
 // 制御されます。アセンブリに関連付けられている情報を変更するには、
 // これらの属性値を変更してください。
-[assembly: AssemblyTitle("BIDS Shared Memory Library for BVE5")]
+[assembly: AssemblyTitle("BIDS Shared Memory Library for BVE5 and BVE6")]
 [assembly: AssemblyDescription("Write the driving data to Shared Memory")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Tech Otter")]
 [assembly: AssemblyProduct("BIDS Project")]
-[assembly: AssemblyCopyright("Copyright © Tetsu Otter 2019")]
+[assembly: AssemblyCopyright("Copyright © Tetsu Otter 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]

--- a/BIDSSMemLib/Ats.cs
+++ b/BIDSSMemLib/Ats.cs
@@ -1,5 +1,4 @@
-﻿#if x86
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -247,4 +246,3 @@ namespace TR.BIDSSMemLib
 
   }
 }
-#endif

--- a/BIDSSMemLib/BIDSSMemLib.csproj
+++ b/BIDSSMemLib/BIDSSMemLib.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;x86</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;x86</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -63,7 +63,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -88,7 +88,7 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Mackoy.IInputDevice">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\mackoy\BveTs5\Mackoy.IInputDevice.DLL</HintPath>
+      <HintPath>C:\Program Files (x86)\mackoy\BveTs5\Mackoy.IInputDevice.DLL</HintPath>
     </Reference>
     <Reference Include="OpenBveApi">
       <HintPath>..\..\OpenBVE\bin_release\OpenBveApi.dll</HintPath>
@@ -125,7 +125,9 @@
     <DllExportMetaLibName>DllExport.dll</DllExportMetaLibName>
     <DllExportNamespace>TR.BIDSSMemLib</DllExportNamespace>
     <DllExportDDNSCecil>true</DllExportDDNSCecil>
-    <PlatformTarget>x86</PlatformTarget>
+    <DllExportSkipOnAnyCpu>false</DllExportSkipOnAnyCpu>
+    <PlatformTarget Condition="'$(Platform)' == 'x86'">x86</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
     <DllExportOrdinalsBase>1</DllExportOrdinalsBase>
     <DllExportGenExpLib>false</DllExportGenExpLib>
     <DllExportOurILAsm>false</DllExportOurILAsm>

--- a/BIDSSMemLib/SMemCtrler.cs
+++ b/BIDSSMemLib/SMemCtrler.cs
@@ -42,7 +42,8 @@ namespace TR
 				ARDoing = true;
 				while (ARDoing && !disposing && !disposedValue)
 				{
-					_ = ReadAction.BeginInvoke(ReadAction.EndInvoke, null);
+					//_ = ReadAction.BeginInvoke(ReadAction.EndInvoke, null);
+					ReadAction.Invoke();
 #if UMNGD
 					Thread.Sleep((int)ARInterval);
 #else

--- a/BIDSSMemLib/SMemIF.cs
+++ b/BIDSSMemLib/SMemIF.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
 using System.IO;
 #if !UMNGD
 using System.IO.MemoryMappedFiles;


### PR DESCRIPTION
とりあえずBVE6.0rc版で読めるように修正.

## 修正点(bve5 project)
- x64 PlatformのSupport
- TargetFrameworkを3.5から4.7.2にUpgrade
  - MemoryMappedFileクラスを使えるようになりました!
  - ParallelおよびTaskクラスを使えるようになりました!
  - 上記機能が使用できるようになったため, 互換用の実装を使用しないように修正
- x86とx64を見分けることができるよう, TargetPlatformに応じて出力ファイルのリネームコピーを作成するように修正
- 念のためVersionの変更を実施

## 動作確認環境
- 環境1
  - Windows10 Home Build:19041.329
  - 64bitオペレーティングシステム x64ベースプロセッサ
  - Intel Core i5-8265U
  - 16GB RAM
  - BVE Trainsim Version 6.0.7472.42239 (BVE6.0)
    - 路線 : Bve Trainsim 内房線内 内房線路線データ (by 内房線制作チーム) Version2020/06/19
    - 車両 : Bve Trainsim 内房線内 E217系車両データ (by 内房線制作チーム) Version2020/06/19
      - 車両データ内detailmodules.txtにTR.BIDSSMemLib.bve5.\<TargetPlatform\>.dllを追加設定したものにて, BVE側からの出力を確認しました.

