### PR TITLE
Fix SMemIF capacity bug #17

### DIFF
--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -14,6 +14,8 @@ namespace TR
 		static readonly long IntDataRandomRWTest_Capacity = 8;
 		static readonly int IntDataRandomRWTest_MaxPos = 0x10000;
 		static readonly int IntDataRandomRWTest_Count = 10000;
+		const int ArrCount_Max = 0x400;
+		const int ArrTest_RepeatCount = 10;
 
 		static int random_int => new Random().Next();
 		static double random_double => new Random().NextDouble();
@@ -111,7 +113,7 @@ namespace TR
 
 		#region ArrayDataReadWriteTests
 		[Test]
-		public void IntArrReadWriteTest([Random(1, 0x1000, 10)] int test_data_len)
+		public void IntArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
 			string smem_name = $"{nameof(IntArrReadWriteTest)}_{random_int}";
 			var test_data = new int[test_data_len];
@@ -123,7 +125,7 @@ namespace TR
 		}
 
 		[Test]
-		public void DoubleArrReadWriteTest([Random(1, 0x1000, 10)] int test_data_len)
+		public void DoubleArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
 			string smem_name = $"{nameof(DoubleArrReadWriteTest)}_{random_int}";
 			var test_data = new double[test_data_len];
@@ -135,7 +137,7 @@ namespace TR
 		}
 
 		[Test]
-		public void CustomStructArrReadWriteTest([Random(1, 0x1000, 10)] int test_data_len)
+		public void CustomStructArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
 			string smem_name = $"{nameof(CustomStructArrReadWriteTest)}_{random_int}";
 			var test_data = new CustomStruct[test_data_len];

--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -41,6 +41,7 @@ namespace TR
 		#region OneDataReadWriteTests
 		/// <summary>int型のデータをRWするテスト</summary>
 		/// <param name="pos">書き込みを開始する位置 [バイト目]</param>
+		[Parallelizable]
 		[TestCaseSource(nameof(IntArgCases_0_32))]
 		public void IntDataReadWriteTest(int pos)
 		{
@@ -52,6 +53,7 @@ namespace TR
 
 		/// <summary>double型のデータをRWするテスト</summary>
 		/// <param name="pos">書き込みを開始する位置 [バイト目]</param>
+		[Parallelizable]
 		[TestCaseSource(nameof(IntArgCases_0_32))]
 		public void DoubleDataReadWriteTest(int pos)
 		{
@@ -75,6 +77,7 @@ namespace TR
 
 		/// <summary>任意の構造体型のデータをRWするテスト</summary>
 		/// <param name="pos">書き込みを開始する位置 [バイト目]</param>
+		[Parallelizable]
 		[TestCaseSource(nameof(IntArgCases_0_32))]
 		public void CustomStructDataReadWriteTest(int pos)
 		{
@@ -112,6 +115,7 @@ namespace TR
 		#endregion
 
 		#region ArrayDataReadWriteTests
+		[Parallelizable]
 		[Test]
 		public void IntArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
@@ -124,6 +128,7 @@ namespace TR
 			ArrDataRWTest(smem_name, 0, test_data);
 		}
 
+		[Parallelizable]
 #if NET35
 		[Test, Explicit]
 #else
@@ -140,6 +145,7 @@ namespace TR
 			ArrDataRWTest(smem_name, 0, test_data);
 		}
 
+		[Parallelizable]
 #if NET35
 		[Test, Explicit]
 #else

--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -159,11 +159,8 @@ namespace TR
 				$"      pos:\t{pos}\n" +
 				$"   length:\t{test_data.Length}"); //実行内容確認用の出力
 
-			//Reader側はちゃんとCapacityを設定しないと読み込みに失敗するので注意
 			using SMemIF target_reader = new(smem_name, Marshal.SizeOf<T>() * test_data.Length);
-
-			//Writer側はCapacityを自動で拡張してくれる
-			using SMemIF target_writer = new(smem_name, OneDataReadWriteTest_Capacity);
+			using SMemIF target_writer = new(smem_name, Marshal.SizeOf<T>() * test_data.Length);
 
 			//書き込みに成功しているかどうか
 			Assert.IsTrue(target_writer.WriteArray(pos, test_data, 0, test_data.Length));

--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -159,8 +159,9 @@ namespace TR
 				$"      pos:\t{pos}\n" +
 				$"   length:\t{test_data.Length}"); //実行内容確認用の出力
 
-			using SMemIF target_reader = new(smem_name, Marshal.SizeOf<T>() * test_data.Length);
-			using SMemIF target_writer = new(smem_name, Marshal.SizeOf<T>() * test_data.Length);
+			long Capacity_Request = Marshal.SizeOf<T>() * test_data.Length;
+			using SMemIF target_reader = new(smem_name, Capacity_Request);
+			using SMemIF target_writer = new(smem_name, Capacity_Request);
 
 			//書き込みに成功しているかどうか
 			Assert.IsTrue(target_writer.WriteArray(pos, test_data, 0, test_data.Length));
@@ -180,8 +181,9 @@ namespace TR
 			string smem_name = $"{nameof(IntDataReadWriteTest)}_{random_int}";
 
 			//ReaderはちゃんとCapacityを設定しないと, データが大きすぎたとき(1000項目以上くらい)に正常にReadできなくなる
-			using SMemIF target_reader = new(smem_name, sizeof(int) * (IntDataRandomRWTest_MaxPos) + 1);
-			using SMemIF target_writer = new(smem_name, IntDataRandomRWTest_Capacity);
+			long Capacity_Request = sizeof(int) * (IntDataRandomRWTest_MaxPos + 1);
+			using SMemIF target_reader = new(smem_name, Capacity_Request);
+			using SMemIF target_writer = new(smem_name, Capacity_Request);
 
 			for (int i = 0; i < IntDataRandomRWTest_Count; i++)
 			{

--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -124,7 +124,11 @@ namespace TR
 			ArrDataRWTest(smem_name, 0, test_data);
 		}
 
+#if NET35
+		[Test, Explicit]
+#else
 		[Test]
+#endif
 		public void DoubleArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
 			string smem_name = $"{nameof(DoubleArrReadWriteTest)}_{random_int}";
@@ -136,7 +140,11 @@ namespace TR
 			ArrDataRWTest(smem_name, 0, test_data);
 		}
 
+#if NET35
+		[Test, Explicit]
+#else
 		[Test]
+#endif
 		public void CustomStructArrReadWriteTest([Random(1, ArrCount_Max, ArrTest_RepeatCount)] int test_data_len)
 		{
 			string smem_name = $"{nameof(CustomStructArrReadWriteTest)}_{random_int}";
@@ -177,7 +185,11 @@ namespace TR
 		}
 		#endregion
 
+#if NET35
+		[Test, Explicit]
+#else
 		[Test]
+#endif
 		public void IntDataRandomRWTest()
 		{
 			string smem_name = $"{nameof(IntDataReadWriteTest)}_{random_int}";

--- a/TR.SMemIF.Tests/SMemIF.Tests.cs
+++ b/TR.SMemIF.Tests/SMemIF.Tests.cs
@@ -159,7 +159,7 @@ namespace TR
 				$"      pos:\t{pos}\n" +
 				$"   length:\t{test_data.Length}"); //実行内容確認用の出力
 
-			long Capacity_Request = Marshal.SizeOf<T>() * test_data.Length;
+			long Capacity_Request = Marshal.SizeOf(default(T)) * test_data.Length;
 			using SMemIF target_reader = new(smem_name, Capacity_Request);
 			using SMemIF target_writer = new(smem_name, Capacity_Request);
 

--- a/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
+++ b/TR.SMemIF.Tests/TR.SMemIF.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFrameworks>net35;net5.0-windows</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>

--- a/TR.SMemIF/ISMemIF.cs
+++ b/TR.SMemIF/ISMemIF.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+namespace TR
+{
+	/// <summary>.net4.0未満かそれ以上かを気にすることなく共有メモリ空間にアクセスする機能を提供するクラスのインターフェイス</summary>
+	public interface ISmemIF : ISMemIF_Reader, ISMemIF_Writer
+	{
+
+	}
+
+	/// <summary>SMemIFの読み込み機能を提供する際のインターフェイス</summary>
+	public interface ISMemIF_Reader : IDisposable
+	{
+		/// <summary>共有メモリ空間の名前</summary>
+		string SMemName { get; }
+
+		/// <summary>共有メモリ空間のキャパシティ</summary>
+		/// <remarks>キャパシティの変更には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
+		long Capacity { get; set; }
+
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		bool Read<T>(long pos, out T buf) where T : struct;
+
+		/// <summary>SMemから連続的に値を読み取ります.</summary>
+		/// <typeparam name="T">値の型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み取り結果を格納する配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">読み取りを行う数</param>
+		/// <returns>読み取りに成功したかどうか</returns>
+		bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct;
+	}
+
+	/// <summary>SMemIFの書き込み機能を提供する際のインターフェイス</summary>
+	public interface ISMemIF_Writer : IDisposable
+	{
+		/// <summary>共有メモリ空間の名前</summary>
+		string SMemName { get; }
+		/// <summary>共有メモリ空間のキャパシティ</summary>
+		/// <remarks>減少方向への操作には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
+		long Capacity { get; set; }
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public bool Write<T>(long pos, ref T buf) where T : struct;
+
+		/// <summary>SMemに連続した値を書き込みます</summary>
+		/// <typeparam name="T">書き込む値の型</typeparam>
+		/// <param name="pos">書き込みを開始するSMem内の位置 [bytes]</param>
+		/// <param name="buf">SMemに書き込む配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">書き込む要素数</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct;
+	}
+}

--- a/TR.SMemIF/ISMemIF.cs
+++ b/TR.SMemIF/ISMemIF.cs
@@ -15,8 +15,7 @@ namespace TR
 		string SMemName { get; }
 
 		/// <summary>共有メモリ空間のキャパシティ</summary>
-		/// <remarks>キャパシティの変更には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
-		long Capacity { get; set; }
+		long Capacity { get; }
 
 		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
 		/// <typeparam name="T">読み込みたい型</typeparam>
@@ -42,7 +41,7 @@ namespace TR
 		string SMemName { get; }
 		/// <summary>共有メモリ空間のキャパシティ</summary>
 		/// <remarks>減少方向への操作には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
-		long Capacity { get; set; }
+		long Capacity { get; }
 
 		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
 		/// <typeparam name="T">データの型</typeparam>

--- a/TR.SMemIF/RWSemap.cs
+++ b/TR.SMemIF/RWSemap.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Runtime.CompilerServices;
-#if !(NET35 || NET20)
-using System.Threading.Tasks;
-#endif
 
 namespace TR
 {
@@ -11,11 +8,20 @@ namespace TR
 	public class RWSemap : IDisposable
 	{
 		private const MethodImplOptions MIOpt = (MethodImplOptions)256;//MethodImplOptions.AggressiveInlining;
-		private long WAIT_TICK = 1;//別モード動作中に, モード復帰をチェックする間隔[tick]
-		private int Reading = 0;//Read操作中のActionの数 (Interlockedで操作を行う)
-		private int Want_to_Write = 0;//Write操作待機中, あるいは実行中のActionの数 (Interlockedで操作を行う)
 
-		private object LockObj = new object();//Writeロックを管理するobject
+		/// <summary>別モード動作中に, モード復帰をチェックする間隔[tick]</summary>
+		static private long WAIT_TICK { get; } = 1;
+
+		/// <summary>別モード動作中に, モード復帰をチェックする間隔[tick]</summary>
+		static private TimeSpan WAIT_TICK_TIMESPAN { get; } = TimeSpan.FromTicks(WAIT_TICK);
+
+		/// <summary>Read操作中のActionの数 (Interlockedで操作を行う)</summary>
+		private int Reading = 0;
+
+		/// <summary>Write操作待機中, あるいは実行中のActionの数 (Interlockedで操作を行う)</summary>
+		private int Want_to_Write = 0;
+
+		private readonly object LockObj = new object();//Writeロックを管理するobject
 
 		/// <summary>リソースを解放します(予定)</summary>
 		public void Dispose() { }
@@ -24,21 +30,11 @@ namespace TR
 		/// <param name="act">読み取り操作</param>
 		/// <returns>成功したかどうか</returns>
 		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public
-#if NET35 || NET20
-			bool
-#else
-			async Task<bool>
-#endif
-			Read(Action<object> act)//net2.0対応のため, object型引数を指定  処理的には不要
+		public void Read(Action<object?> act)//net2.0対応のため, object型引数を指定  処理的には不要
 		{
 			while (Want_to_Write > 0)//Writeロック取得待機
-			{
-#if !(NET35 || NET20)
-				await
-#endif
-				Delay(TimeSpan.FromTicks(WAIT_TICK));
-			}
+				Thread.Sleep(WAIT_TICK_TIMESPAN);
+
 			try
 			{
 				Interlocked.Increment(ref Reading);
@@ -48,32 +44,20 @@ namespace TR
 			{
 				Interlocked.Decrement(ref Reading);
 			}
-			return true;
 		}
 
 		/// <summary>Readロックを行ったうえで, 指定の書き込み操作を実行します</summary>
 		/// <param name="act">書き込み操作</param>
 		/// <returns>成功したかどうか</returns>
 		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public
-#if NET35 || NET20
-			bool
-#else
-			async Task<bool>
-#endif
-	Write(Action<object> act)//net2.0対応のため, object型引数を指定  処理的には不要
+		public void Write(Action<object?> act)//net2.0対応のため, object型引数を指定  処理的には不要
 		{
 			try
 			{
 				Interlocked.Increment(ref Want_to_Write);//Write待機
 				while (Reading > 0)//Read完了待機
-				{
-#if !(NET35 || NET20)
-					await
-#endif
-					Delay(TimeSpan.FromTicks(WAIT_TICK));
+					Thread.Sleep(WAIT_TICK_TIMESPAN);
 
-				}
 				lock (LockObj)//Writeロック
 				{
 					act?.Invoke(null);
@@ -83,15 +67,6 @@ namespace TR
 			{
 				Interlocked.Decrement(ref Want_to_Write);//Write完了処理
 			}
-			return true;
 		}
-
-#if NET35 || NET20
-		static private void Delay(TimeSpan ts) => Thread.Sleep(ts);
-#else
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		static private async Task Delay(TimeSpan ts) => await Task.Delay(ts);
-#endif
-
 	}
 }

--- a/TR.SMemIF/SMemIF.cs
+++ b/TR.SMemIF/SMemIF.cs
@@ -1,143 +1,31 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-#if NET35 || NET20
-using System.IO;
-#else
-using System.IO.MemoryMappedFiles;
-#endif
+﻿
 //ref : https://docs.microsoft.com/ja-jp/dotnet/standard/library-guidance/cross-platform-targeting
 namespace TR
 {
 	/// <summary>TargetFramework別にSharedMemoryを提供します.</summary>
-	public class SMemIF : IDisposable
+	public class SMemIF : SemaphorelessSMemIF
 	{
-		private const MethodImplOptions MIOpt = (MethodImplOptions)256;//MethodImplOptions.AggressiveInlining;
-		const byte TRUE_VALUE = 1;
-		const byte FALSE_VALUE = 0;
-		
-#if NET35 || NET20//Unmanaged
-		#region 関数のリンク
-		const string DLL_NAME = "kernel32.dll";
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern IntPtr CreateFileMappingA(
-			IntPtr hFile,
-			IntPtr lpFileMappingAttributes,
-			uint flProtect,
-			uint dwMaximumSizeHigh,
-			uint dwMaximumSizeLow,
-			string lpName);
+		private RWSemap Semap { get; }
 
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern IntPtr OpenFileMapping(
-			uint dwDesiredAccess,
-			byte bInheritHandle,
-			string lpName);
-
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern IntPtr MapViewOfFile(
-	IntPtr hFileMappingObject,
-	uint dwDesiredAccess,
-	uint dwFileOffsetHigh,
-	uint dwFileOffsetLow,
-	uint dwNumberOfBytesToMap
-);
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern byte CloseHandle(IntPtr hObject);
-
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern byte UnmapViewOfFile(IntPtr lpBaseAddress);
-
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern byte FlushViewOfFile(
-	IntPtr lpBaseAddress,
-	uint dwNumberOfBytesToFlush
-);
-
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
-		static extern uint GetLastError();
-		#endregion
-
-		#region FileMappingまわりの定数
-		const uint ERROR_ALREADY_EXISTS = 0xB7;
-		#region flProtect
-		const uint PAGE_EXECUTE_READ = 0x20;
-		const uint PAGE_EXECUTE_READWRITE = 0x40;
-		const uint PAGE_EXECUTE_WRITECOPY = 0x80;
-		const uint PAGE_READONLY = 0x02;
-		const uint PAGE_READWRITE = 0x04;
-		const uint PAGE_WRITECOPY = 0x08;
-
-		const uint SEC_COMMIT = 0x8000000;
-		const uint SEC_IMAGE = 0x1000000;
-		const uint SEC_IMAGE_NO_EXECUTE = 0x11000000;
-		const uint SEC_LARGE_PAGES = 0x80000000;
-		const uint SEC_NOCACHE = 0x10000000;
-		const uint SEC_RESERVE = 0x4000000;
-		const uint SEC_WRITECOMBINE = 0x40000000;
-		#endregion
-
-		#region dwDesiredAccess
-		const uint FILE_MAP_ALL_ACCESS = 0xf001f;
-		const uint FILE_MAP_READ = 0x04;
-		const uint FILE_MAP_WRITE = 0x02;
-		const uint FILE_MAP_COPY = 0x01;
-		//const uint FILE_MAP_EXECUTE = 0;
-		//const uint FILE_MAP_LARGE_PAGES = 0;
-		//const uint FILE_MAP_TARGETS_INVALID = 0;
-		#endregion
-
-		#endregion
-
-
-		IntPtr MMF = IntPtr.Zero;//Memory Mapped File
-		IntPtr MMVA = IntPtr.Zero;//Memory Mapped View Accessor (object格納場所)
-#else
-		MemoryMappedFile MMF = null;
-		MemoryMappedViewAccessor MMVA = null;
-#endif
-
-		long Capacity
-#if NET35 || NET20
-		{ get; set; } = 0;
-#else
-			=> MMVA?.Capacity ?? 0;
-#endif
-
-		string SMem_Name { get; }
-		RWSemap semap = null;
-
-
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public SMemIF(string SMemName, long capacity)
+		/// <summary>インスタンスを初期化する</summary>
+		/// <param name="smem_name">共有メモリ空間の名前</param>
+		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
+		public SMemIF(string smem_name, long capacity) : base(smem_name, capacity)
 		{
-			if (string.IsNullOrEmpty(SMemName) || capacity <= 0) Dispose();
-			SMem_Name = SMemName;
-			semap = new RWSemap();
-
-			CheckReOpen(capacity);
+			Semap = new RWSemap();
 		}
 
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public bool Read<T>(long pos, out T buf) where T : struct
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		public override bool Read<T>(long pos, out T buf) where T : struct
 		{
-			buf = default;
-			if (pos < 0) throw new ArgumentOutOfRangeException("posに負の値は使用できません.");
-			if (disposing) return false;
-
-			CheckReOpen(pos + Marshal.SizeOf(default(T)));
 			T retT = default;
-			_ = semap.Read((_) =>
-			{
-				#region SMemへの操作
-#if NET35 || NET20
-				if (MMVA == IntPtr.Zero) return;
-				retT = (T)Marshal.PtrToStructure(MMVA, typeof(T));
-#else
-				MMVA.Read(pos, out retT);
-#endif
-				#endregion
-			});
+
+			Semap.Read((_) => base.Read(pos, out retT) );
+
 			buf = retT;
 			return true;
 		}
@@ -149,62 +37,24 @@ namespace TR
 		/// <param name="offset">配列内で書き込みを開始する位置</param>
 		/// <param name="count">読み取りを行う数</param>
 		/// <returns>読み取りに成功したかどうか</returns>
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			if (disposing) return false;
-
-			long neededCap = pos + Marshal.SizeOf((T)default) * (count - offset);
-			CheckReOpen(neededCap);
-			_ = semap.Read((_) =>
-				{
-					#region SMemへの操作
-#if NET35 || NET20
-					if (MMVA == IntPtr.Zero) return;
-					IntPtr ip_toRead = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-					if (buf is int[] iarr)//int型配列にキャスト(iarrへの書き込みはbufにも反映される)
-					{
-						Marshal.Copy(ip_toRead, iarr, offset, count);//iarrにSMemの値を書き込み
-					}
-					else if(buf is bool[] barr)//bool型配列にキャスト
-					{
-						byte[] SMem_ba = new byte[sizeof(bool) * count];//SMemから読んだRAW値のキャッシュ
-
-						//ip_toReadの初めから, SMem_ba[offset]~ count個コピーする.
-						Marshal.Copy(ip_toRead, SMem_ba, 0, SMem_ba.Length);//SMemからキャッシュにコピー
-
-						for(int i = 0; i < SMem_ba.Length; i++)
-							barr[i + offset] = SMem_ba[i] == TRUE_VALUE;//読み取り結果の書き込み
-					}
-					else throw new ArrayTypeMismatchException("NET35 || NET20モードでBuildされています.  Array操作はint型/bool型のみ受け付けます.");
-
-#else
-				MMVA.ReadArray(pos, buf, offset, count);
-#endif
-					#endregion
-				});
+			Semap.Read((_) => base.ReadArray(pos, buf, offset, count));
 
 			return true;
 		}
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public bool Write<T>(long pos, ref T buf) where T : struct
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool Write<T>(long pos, ref T buf) where T : struct
 		{
-			if (pos < 0) throw new ArgumentOutOfRangeException("posに負の値は使用できません.");
-			if (disposing) return false;
-			CheckReOpen(pos + Marshal.SizeOf(default(T)));
 			T retT = buf;
-			_ = semap.Write((_) =>
-				{
-					#region SMemへの操作
-#if NET35 || NET20
-					if (MMVA == IntPtr.Zero) return;//Viewが無効
-					IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-					Marshal.StructureToPtr(retT, MMVA, false);//予め確保してた場所にStructureを書き込む
-#else
-				MMVA.Write(pos, ref retT);
-#endif
-					#endregion
-				});
+
+			Semap.Write((_) => base.Write(pos, ref retT) );
+
 			return true;
 		}
 
@@ -215,115 +65,30 @@ namespace TR
 		/// <param name="offset">配列内で書き込みを開始する位置</param>
 		/// <param name="count">書き込む要素数</param>
 		/// <returns>書き込みに成功したかどうか</returns>
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		public bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			if (disposing) return false;
-			long neededCap = pos + Marshal.SizeOf((T)default) * (count - offset);
-			CheckReOpen(neededCap);
-			_ = semap.Write((_) =>
-				{
-					#region SMemへの操作
-#if NET35 || NET20
-					if (MMVA == IntPtr.Zero) return;
-					IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-					if (buf is int[] iarr)//int型配列にキャスト(iarrへの書き込みはbufにも反映される)
-					{
-						Marshal.Copy(iarr, offset, ip_writeTo, count);
-					}
-					else if(buf is bool[] barr)
-					{
-						byte[] ba2w = new byte[count];//SMemに書き込む配列
-						for (int i = 0; i < ba2w.Length; i++)
-							ba2w[i] = barr[i + offset] ? TRUE_VALUE : FALSE_VALUE;//SMemに実際に書き込む配列に, 入力された値を書き込む
+			Semap.Write((_) => base.WriteArray(pos, buf, offset, count) );
 
-						Marshal.Copy(ba2w, 0, ip_writeTo, ba2w.Length);//SMemに書き込む
-					}
-					else throw new ArrayTypeMismatchException("NET35 || NET20モードでBuildされています.  Array操作はint/bool型のみ受け付けます.");
-#else
-				MMVA.WriteArray(pos, buf, offset, count);
-#endif
-					#endregion
-				});
 			return true;
-		}
-
-		[MethodImpl(MIOpt)]//関数のインライン展開を積極的にやってもらう.
-		void CheckReOpen(long capacity)
-		{
-			if (Capacity > capacity) return;//保持キャパが要求キャパより大きい
-			_ = semap.Write((_) =>
-				{
-					if (Capacity > capacity) return;//保持キャパが要求キャパより大きい 再確認
-#if NET35 || NET20
-					if (MMVA != IntPtr.Zero)
-					{
-						UnmapViewOfFile(MMVA);
-						CloseHandle(MMVA);
-					}//Viewを閉じる
-					if (MMF != IntPtr.Zero) CloseHandle(MMF);//FileハンドルをRelease
-
-					if (capacity > uint.MaxValue) throw new ArgumentOutOfRangeException("NET35 || NET20モードでは, CapacityはUInt32.MaxValue以下である必要があります.");
-
-					MMF = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE_VALUE, SMem_Name);//最初はOpenを試行
-					if (MMF == IntPtr.Zero) MMF = CreateFileMappingA(unchecked((IntPtr)(int)0xFFFFFFFF), IntPtr.Zero, PAGE_READWRITE, 0, (uint)capacity, SMem_Name);//Openできない=>つくる
-					if (MMF == IntPtr.Zero) throw new FileLoadException(string.Format("SMemIF.CheckReOpen({0}) : Memory Mapped File ({1}) のCreate/Openに失敗しました.", capacity, SMem_Name));//OpenもCreateもできなければException
-
-					MMVA = MapViewOfFile(MMF, FILE_MAP_ALL_ACCESS, 0, 0, 0);
-					Capacity = capacity;
-#else
-				MMVA?.Dispose();
-					MMF?.Dispose();
-
-					MMF = MemoryMappedFile.CreateOrOpen(SMem_Name, capacity);
-					MMVA = MMF.CreateViewAccessor();
-#endif
-				});
 		}
 
 
 		#region IDisposable Support
-		public bool disposing = false;
-		private bool disposedValue = false;
-
-		protected virtual void Dispose(bool disposing)
+		/// <summary>保持しているリソースを解放する</summary>
+		/// <param name="disposing">Managedリソースも解放するかどうか</param>
+		protected override void Dispose(bool disposing)
 		{
 			disposing = true;
 			if (!disposedValue)
 			{
 				if (disposing)
 				{
-#if NET35 || NET20
-					if (MMVA != IntPtr.Zero)
-					{
-						UnmapViewOfFile(MMVA);
-						CloseHandle(MMVA);
-						MMVA = IntPtr.Zero;
-					}
-					if (MMF != IntPtr.Zero)
-					{
-						CloseHandle(MMF);
-						MMF = IntPtr.Zero;
-					}
-#else
-					MMVA?.Dispose();
-					MMF?.Dispose();
-
-					MMVA = null;
-					MMF = null;
-#endif
-					semap?.Dispose();
-					semap = null;
+					Semap?.Dispose();
 
 					disposedValue = true;
 				}
 			}
 		}
-#if NET35 || NET20
-		/// <summary>SMemのハンドルを閉じます.</summary>
-		~SMemIF() => Dispose(false);
-#endif
-		public void Dispose() => Dispose(true);
 #endregion
 
 	}

--- a/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace TR
+{
+	/// <summary>セマフォレスに共有メモリ空間へのアクセスを提供する各処理の前処理を実装したクラス</summary>
+	public abstract class SemaphorelessSMemIF_Preprocessing : ISmemIF
+	{
+		/// <summary>リソースの解放中, あるいは解放に完了しているかどうか</summary>
+		protected bool disposingValue { get; set; } = false;
+
+		/// <summary>共有メモリの名前</summary>
+		public string SMemName { get; }
+
+		/// <summary>共有メモリ空間のキャパシティ</summary>
+		/// <remarks>setterにてキャパシティの増減機能を実装する</remarks>
+		public abstract long Capacity { get; set; }
+
+		/// <summary>与えられた型が使用する領域のサイズを計算する</summary>
+		/// <typeparam name="T">領域を計算する型</typeparam>
+		/// <returns>サイズ [bytes]</returns>
+		public static long getElemSize<T>() where T : struct => Marshal.SizeOf(default(T));
+
+		/// <summary>必要になるキャパシティを計算する</summary>
+		/// <typeparam name="T">領域を計算する型</typeparam>
+		/// <param name="pos">読み書きを行う位置 [bytes]</param>
+		/// <param name="count">データの数 [個]</param>
+		/// <returns>サイズ [bytes]</returns>
+		public static long getNeededCapacity<T>(in long pos, in int count = 1) where T : struct => pos + getElemSize<T>() * count;
+
+		/// <summary>インスタンスを初期化する</summary>
+		/// <param name="smem_name">共有メモリ空間の名前としてセットする文字列</param>
+		/// <param name="capacity">初期化時点で取得する共有メモリ空間のキャパシティ</param>
+		public SemaphorelessSMemIF_Preprocessing(in string smem_name, in long capacity)
+		{
+			if (string.IsNullOrEmpty(smem_name))
+				throw new ArgumentOutOfRangeException(nameof(smem_name), "smem_name cannot be null or empty");
+			else if (capacity <= 0)
+				throw new ArgumentOutOfRangeException(nameof(capacity), "capacity cannot be 0 or less");
+
+			SMemName = smem_name;
+		}
+
+		/// <summary>リソースの解放を行う</summary>
+		public virtual void Dispose() => disposingValue = true;
+
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		public virtual bool Read<T>(long pos, out T buf) where T : struct
+		{
+			buf = default;
+
+			if (disposingValue)
+				return false; //解放が開始したら実行しない
+
+			CheckReOpen(getNeededCapacity<T>(pos));
+
+			return true;
+		}
+
+		/// <summary>SMemから連続的に値を読み取ります</summary>
+		/// <typeparam name="T">値の型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み取り結果を格納する配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">読み取りを行う数</param>
+		/// <returns>読み取りに成功したかどうか</returns>
+		public virtual bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (disposingValue)
+				return false; //解放が開始したら実行しない
+
+			CheckReOpen(getNeededCapacity<T>(pos));
+
+			return true;
+		}
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public virtual bool Write<T>(long pos, ref T buf) where T : struct
+		{
+			if (disposingValue)
+				return false; //解放が開始したら実行しない
+
+			CheckReOpen(getNeededCapacity<T>(pos));
+
+			return true;
+		}
+
+		/// <summary>SMemに連続した値を書き込みます</summary>
+		/// <typeparam name="T">書き込む値の型</typeparam>
+		/// <param name="pos">書き込みを開始するSMem内の位置 [bytes]</param>
+		/// <param name="buf">SMemに書き込む配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">書き込む要素数</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public virtual bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (disposingValue)
+				return false; //解放が開始したら実行しない
+
+			CheckReOpen(getNeededCapacity<T>(pos));
+
+			return true;
+		}
+
+		/// <summary>共有メモリ空間を再度開く必要があるかどうかを確認する</summary>
+		/// <param name="needed_capacity">必要なキャパシティ</param>
+		protected abstract void CheckReOpen(long needed_capacity);
+	}
+}

--- a/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
@@ -14,7 +14,7 @@ namespace TR
 
 		/// <summary>共有メモリ空間のキャパシティ</summary>
 		/// <remarks>setterにてキャパシティの増減機能を実装する</remarks>
-		public abstract long Capacity { get; set; }
+		public abstract long Capacity { get; }
 
 		/// <summary>与えられた型が使用する領域のサイズを計算する</summary>
 		/// <typeparam name="T">領域を計算する型</typeparam>
@@ -39,8 +39,6 @@ namespace TR
 				throw new ArgumentOutOfRangeException(nameof(capacity), "capacity cannot be 0 or less");
 
 			SMemName = smem_name;
-
-			Capacity = capacity;
 		}
 
 		/// <summary>リソースの解放を行う</summary>
@@ -55,12 +53,7 @@ namespace TR
 		{
 			buf = default;
 
-			if (disposingValue)
-				return false; //解放が開始したら実行しない
-
-			CheckReOpen(getNeededCapacity<T>(pos));
-
-			return true;
+			return !disposingValue;
 		}
 
 		/// <summary>SMemから連続的に値を読み取ります</summary>
@@ -70,30 +63,14 @@ namespace TR
 		/// <param name="offset">配列内で書き込みを開始する位置</param>
 		/// <param name="count">読み取りを行う数</param>
 		/// <returns>読み取りに成功したかどうか</returns>
-		public virtual bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
-		{
-			if (disposingValue)
-				return false; //解放が開始したら実行しない
-
-			CheckReOpen(getNeededCapacity<T>(pos));
-
-			return true;
-		}
+		public virtual bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct => !disposingValue;
 
 		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
 		/// <typeparam name="T">データの型</typeparam>
 		/// <param name="pos">書き込む位置 [bytes]</param>
 		/// <param name="buf">書き込むデータ</param>
 		/// <returns>書き込みに成功したかどうか</returns>
-		public virtual bool Write<T>(long pos, ref T buf) where T : struct
-		{
-			if (disposingValue)
-				return false; //解放が開始したら実行しない
-
-			CheckReOpen(getNeededCapacity<T>(pos));
-
-			return true;
-		}
+		public virtual bool Write<T>(long pos, ref T buf) where T : struct => !disposingValue;
 
 		/// <summary>SMemに連続した値を書き込みます</summary>
 		/// <typeparam name="T">書き込む値の型</typeparam>
@@ -102,18 +79,6 @@ namespace TR
 		/// <param name="offset">配列内で書き込みを開始する位置</param>
 		/// <param name="count">書き込む要素数</param>
 		/// <returns>書き込みに成功したかどうか</returns>
-		public virtual bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
-		{
-			if (disposingValue)
-				return false; //解放が開始したら実行しない
-
-			CheckReOpen(getNeededCapacity<T>(pos));
-
-			return true;
-		}
-
-		/// <summary>共有メモリ空間を再度開く必要があるかどうかを確認する</summary>
-		/// <param name="needed_capacity">必要なキャパシティ</param>
-		protected abstract void CheckReOpen(long needed_capacity);
+		public virtual bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct => !disposingValue;
 	}
 }

--- a/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.Preprocessing.cs
@@ -39,6 +39,8 @@ namespace TR
 				throw new ArgumentOutOfRangeException(nameof(capacity), "capacity cannot be 0 or less");
 
 			SMemName = smem_name;
+
+			Capacity = capacity;
 		}
 
 		/// <summary>リソースの解放を行う</summary>

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -20,16 +20,13 @@ namespace TR
 		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
 		public SemaphorelessSMemIF(string smem_name, long capacity) : base(smem_name, capacity)
 		{
-			if (capacity > uint.MaxValue)
-				throw new ArgumentOutOfRangeException("NET35 || NET20モードでは, CapacityはUInt32.MaxValue以下である必要があります.");
-
 			//最初はOpenを試行
 			MMF = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE_VALUE, SMemName);
 
 			long newCap = (long)Math.Ceiling((float)capacity / Capacity_Step) * Capacity_Step;
 			//Openできない => つくる
 			if (MMF == IntPtr.Zero)
-				MMF = CreateFileMappingA(unchecked((IntPtr)(int)0xFFFFFFFF), IntPtr.Zero, PAGE_READWRITE, 0, (uint)newCap, SMemName);
+				MMF = CreateFileMappingA(new IntPtr(-1), IntPtr.Zero, PAGE_READWRITE | SEC_COMMIT, (uint)(newCap >> 32), (uint)newCap, SMemName);
 
 			//OpenもCreateもできなければException
 			if (MMF == IntPtr.Zero)

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -113,7 +113,10 @@ namespace TR
 			}
 			else
 			{
-				
+				//非効率的だけど…
+				long elemSize = getElemSize<T>();
+				for(long i = 0; i < count - offset; i++)
+					_Read(pos + (i * elemSize), out buf[i + offset]);
 			}
 			return true;
 		}
@@ -179,7 +182,12 @@ namespace TR
 				Marshal.Copy(ba2w, 0, ip_writeTo, ba2w.Length);//SMemに書き込む
 			}
 			else
-				throw new ArrayTypeMismatchException("NET35 || NET20モードでBuildされています.  Array操作はint/bool型のみ受け付けます.");
+			{
+				//非効率的だけど…
+				long elemSize = getElemSize<T>();
+				for (long i = 0; i < count - offset; i++)
+					_Write(pos + (i * elemSize), in buf[i + offset]);
+			}
 			return true;
 		}
 

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -80,7 +80,7 @@ namespace TR
 		/// <returns>読み取りに成功したかどうか</returns>
 		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			if (!base.WriteArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
+			if (!base.ReadArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
 				return false;
 
 			//読み取り開始位置適用済みのポインタを取得する
@@ -157,7 +157,7 @@ namespace TR
 		/// <returns>書き込みに成功したかどうか</returns>
 		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			if (!base.ReadArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
+			if (!base.WriteArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
 				return false;
 
 			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -10,6 +10,7 @@ namespace TR
 	{
 		const byte TRUE_VALUE = 1;
 		const byte FALSE_VALUE = 0;
+		const long Capacity_Step = 4096;
 
 		IntPtr MMF = IntPtr.Zero;//Memory Mapped File
 		IntPtr MMVA = IntPtr.Zero;//Memory Mapped View Accessor (object格納場所)
@@ -25,19 +26,20 @@ namespace TR
 			//最初はOpenを試行
 			MMF = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE_VALUE, SMemName);
 
+			long newCap = (long)Math.Ceiling((float)capacity / Capacity_Step) * Capacity_Step;
 			//Openできない => つくる
 			if (MMF == IntPtr.Zero)
-				MMF = CreateFileMappingA(unchecked((IntPtr)(int)0xFFFFFFFF), IntPtr.Zero, PAGE_READWRITE, 0, (uint)capacity, SMemName);
+				MMF = CreateFileMappingA(unchecked((IntPtr)(int)0xFFFFFFFF), IntPtr.Zero, PAGE_READWRITE, 0, (uint)newCap, SMemName);
 
 			//OpenもCreateもできなければException
 			if (MMF == IntPtr.Zero)
-				throw new FileLoadException(string.Format("SMemIF.CheckReOpen({0}) : Memory Mapped File ({1}) のCreate/Openに失敗しました.", capacity, SMemName));
+				throw new FileLoadException($"SMemIF.CheckReOpen({capacity}) : Memory Mapped File ({SMemName}) のCreate/Openに失敗しました.  newCap:{newCap}");
 
 			//Viewをつくる
 			MMVA = MapViewOfFile(MMF, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 
 			//キャパシティ情報を更新
-			Capacity = capacity;
+			Capacity = newCap;
 		}
 
 		/// <summary>共有メモリ空間のキャパシティ</summary>

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -1,0 +1,294 @@
+﻿#if NET20 || NET35
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace TR
+{
+	/// <summary>共有メモリにアクセスする際に, セマフォによる排他制御を呼び出し元で行う場合に使用するクラス</summary>
+	public class SemaphorelessSMemIF : SemaphorelessSMemIF_Preprocessing
+	{
+		const byte TRUE_VALUE = 1;
+		const byte FALSE_VALUE = 0;
+
+		IntPtr MMF = IntPtr.Zero;//Memory Mapped File
+		IntPtr MMVA = IntPtr.Zero;//Memory Mapped View Accessor (object格納場所)
+
+		/// <summary>インスタンスを初期化します</summary>
+		/// <param name="smem_name">共有メモリ空間の名前</param>
+		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
+		public SemaphorelessSMemIF(string smem_name, long capacity) : base(smem_name, capacity)
+		{
+		}
+
+		private long _Capacity = 0;
+		/// <summary>共有メモリ空間のキャパシティ</summary>
+		/// <remarks>キャパシティ変更には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
+		public override long Capacity
+		{
+			get => _Capacity;
+			set
+			{
+				//Viewを閉じる
+				if (MMVA != IntPtr.Zero)
+				{
+					UnmapViewOfFile(MMVA);
+					CloseHandle(MMVA);
+					MMVA = IntPtr.Zero;
+				}
+
+				if (MMF != IntPtr.Zero)
+				{
+					CloseHandle(MMF);//FileハンドルをRelease
+					MMF = IntPtr.Zero;
+				}
+
+				if (value > uint.MaxValue) throw new ArgumentOutOfRangeException("NET35 || NET20モードでは, CapacityはUInt32.MaxValue以下である必要があります.");
+
+				//最初はOpenを試行
+				MMF = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE_VALUE, SMemName);
+
+				//Openできない => つくる
+				if (MMF == IntPtr.Zero)
+					MMF = CreateFileMappingA(unchecked((IntPtr)(int)0xFFFFFFFF), IntPtr.Zero, PAGE_READWRITE, 0, (uint)value, SMemName);
+
+				//OpenもCreateもできなければException
+				if (MMF == IntPtr.Zero)
+					throw new FileLoadException(string.Format("SMemIF.CheckReOpen({0}) : Memory Mapped File ({1}) のCreate/Openに失敗しました.", value, SMemName));
+
+				//Viewをつくる
+				MMVA = MapViewOfFile(MMF, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+
+				//キャパシティ情報を更新
+				_Capacity = value;
+			}
+		}
+
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		public override bool Read<T>(long pos, out T buf) where T : struct
+		{
+			if (!base.Read(pos, out buf) || MMVA == IntPtr.Zero)
+				return false;
+
+			buf = (T)Marshal.PtrToStructure(MMVA, typeof(T));
+			return true;
+		}
+
+		/// <summary>SMemから連続的に値を読み取ります</summary>
+		/// <typeparam name="T">値の型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み取り結果を格納する配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">読み取りを行う数</param>
+		/// <returns>読み取りに成功したかどうか</returns>
+		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.ReadArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
+				return false;
+
+			//読み取り開始位置適用済みのポインタを取得する
+			IntPtr ip_toRead = new IntPtr(MMVA.ToInt64() + pos);
+
+			//int型配列にキャスト(iarrへの書き込みはbufにも反映される)
+			if (buf is int[] iarr)
+			{
+				Marshal.Copy(ip_toRead, iarr, offset, count);//iarrにSMemの値を書き込み
+			}
+			else if(buf is double[] darr)
+			{
+				Marshal.Copy(ip_toRead, darr, offset, count);//darrにSMemの値を書き込み
+			}
+			else if(buf is float[] farr)
+			{
+				Marshal.Copy(ip_toRead, farr, offset, count);//farrにSMemの値を書き込み
+			}
+			else if (buf is bool[] barr)//bool型配列にキャスト
+			{
+				//SMemから読んだRAW値のキャッシュ
+				//bool型は1byteなので, byte配列でなんとかなる
+				byte[] SMem_ba = new byte[sizeof(bool) * count];
+
+				//ip_toReadの初めから, SMem_ba[offset]~ count個コピーする.
+				Marshal.Copy(ip_toRead, SMem_ba, 0, SMem_ba.Length);//SMemからキャッシュにコピー
+
+				for (int i = 0; i < SMem_ba.Length; i++)
+					barr[i + offset] = SMem_ba[i] == TRUE_VALUE;//読み取り結果の書き込み
+			}
+			else
+			{
+				
+			}
+			return true;
+		}
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool Write<T>(long pos, ref T buf) where T : struct
+		{
+			if (!base.Read(pos, out buf) || MMVA == IntPtr.Zero)
+				return false;
+
+			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
+			Marshal.StructureToPtr(buf, MMVA, false);//予め確保してた場所にStructureを書き込む
+			return true;
+		}
+
+		/// <summary>SMemに連続した値を書き込みます</summary>
+		/// <typeparam name="T">書き込む値の型</typeparam>
+		/// <param name="pos">書き込みを開始するSMem内の位置 [bytes]</param>
+		/// <param name="buf">SMemに書き込む配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">書き込む要素数</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.ReadArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
+				return false;
+
+			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
+			if (buf is int[] iarr)//int型配列にキャスト(iarrへの書き込みはbufにも反映される)
+			{
+				Marshal.Copy(iarr, offset, ip_writeTo, count);
+			}
+			else if (buf is bool[] barr)
+			{
+				byte[] ba2w = new byte[count];//SMemに書き込む配列
+				for (int i = 0; i < ba2w.Length; i++)
+					ba2w[i] = barr[i + offset] ? TRUE_VALUE : FALSE_VALUE;//SMemに実際に書き込む配列に, 入力された値を書き込む
+
+				Marshal.Copy(ba2w, 0, ip_writeTo, ba2w.Length);//SMemに書き込む
+			}
+			else throw new ArrayTypeMismatchException("NET35 || NET20モードでBuildされています.  Array操作はint/bool型のみ受け付けます.");
+			return true;
+		}
+
+		#region IDisposable Support
+		/// <summary>リソースの解放が完了したかどうか</summary>
+		protected bool disposedValue = false;
+
+		/// <summary>保持しているリソースを解放する</summary>
+		/// <param name="disposing">Managedリソースも解放するかどうか</param>
+		protected virtual void Dispose(bool disposing)
+		{
+			disposedValue = true;
+
+			if (!disposedValue)
+			{
+				if (MMVA != IntPtr.Zero)
+				{
+					UnmapViewOfFile(MMVA);
+					CloseHandle(MMVA);
+					MMVA = IntPtr.Zero;
+				}
+				if (MMF != IntPtr.Zero)
+				{
+					CloseHandle(MMF);
+					MMF = IntPtr.Zero;
+				}
+
+				disposedValue = true;
+			}
+		}
+
+		/// <summary>SemaphorelessSMemIFのデストラクタ</summary>
+		~SemaphorelessSMemIF() => Dispose(false);
+
+		/// <summary>保持しているリソースを解放する</summary>
+		public override void Dispose()
+		{
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+		#endregion
+
+
+		/// <summary>共有メモリ空間を再度開く必要があるかどうかを確認する</summary>
+		/// <param name="needed_capacity">必要なキャパシティ</param>
+		protected override void CheckReOpen(long needed_capacity)
+		{
+			if (Capacity > needed_capacity)
+				return;//保持キャパが要求キャパより大きいなら, 再度開く必要はない
+
+			Capacity = needed_capacity;
+		}
+
+		#region 関数のリンク
+		const string DLL_NAME = "kernel32.dll";
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern IntPtr CreateFileMappingA(
+			IntPtr hFile,
+			IntPtr lpFileMappingAttributes,
+			uint flProtect,
+			uint dwMaximumSizeHigh,
+			uint dwMaximumSizeLow,
+			string lpName);
+
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern IntPtr OpenFileMapping(
+			uint dwDesiredAccess,
+			byte bInheritHandle,
+			string lpName);
+
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern IntPtr MapViewOfFile(
+			IntPtr hFileMappingObject,
+			uint dwDesiredAccess,
+			uint dwFileOffsetHigh,
+			uint dwFileOffsetLow,
+			uint dwNumberOfBytesToMap);
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern byte CloseHandle(IntPtr hObject);
+
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern byte UnmapViewOfFile(IntPtr lpBaseAddress);
+
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern byte FlushViewOfFile(
+			IntPtr lpBaseAddress,
+			uint dwNumberOfBytesToFlush);
+
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		static extern uint GetLastError();
+		#endregion
+
+		#region FileMappingまわりの定数
+		const uint ERROR_ALREADY_EXISTS = 0xB7;
+		#region flProtect
+		const uint PAGE_EXECUTE_READ = 0x20;
+		const uint PAGE_EXECUTE_READWRITE = 0x40;
+		const uint PAGE_EXECUTE_WRITECOPY = 0x80;
+		const uint PAGE_READONLY = 0x02;
+		const uint PAGE_READWRITE = 0x04;
+		const uint PAGE_WRITECOPY = 0x08;
+
+		const uint SEC_COMMIT = 0x8000000;
+		const uint SEC_IMAGE = 0x1000000;
+		const uint SEC_IMAGE_NO_EXECUTE = 0x11000000;
+		const uint SEC_LARGE_PAGES = 0x80000000;
+		const uint SEC_NOCACHE = 0x10000000;
+		const uint SEC_RESERVE = 0x4000000;
+		const uint SEC_WRITECOMBINE = 0x40000000;
+		#endregion
+
+		#region dwDesiredAccess
+		const uint FILE_MAP_ALL_ACCESS = 0xf001f;
+		const uint FILE_MAP_READ = 0x04;
+		const uint FILE_MAP_WRITE = 0x02;
+		const uint FILE_MAP_COPY = 0x01;
+		//const uint FILE_MAP_EXECUTE = 0;
+		//const uint FILE_MAP_LARGE_PAGES = 0;
+		//const uint FILE_MAP_TARGETS_INVALID = 0;
+		#endregion
+
+		#endregion
+	}
+}
+
+#endif

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -74,7 +74,8 @@ namespace TR
 			if (!base.Read(pos, out buf) || MMVA == IntPtr.Zero)
 				return false;
 
-			buf = (T)Marshal.PtrToStructure(MMVA, typeof(T));
+			IntPtr ip_readFrom = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
+			buf = (T)Marshal.PtrToStructure(ip_readFrom, typeof(T));
 			return true;
 		}
 
@@ -136,7 +137,7 @@ namespace TR
 				return false;
 
 			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-			Marshal.StructureToPtr(buf, MMVA, false);//予め確保してた場所にStructureを書き込む
+			Marshal.StructureToPtr(buf, ip_writeTo, false);//予め確保してた場所にStructureを書き込む
 			return true;
 		}
 

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -87,7 +87,7 @@ namespace TR
 		/// <returns>読み取りに成功したかどうか</returns>
 		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
 		{
-			if (!base.ReadArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
+			if (!base.WriteArray(pos, buf, offset, count) || MMVA == IntPtr.Zero)
 				return false;
 
 			//読み取り開始位置適用済みのポインタを取得する
@@ -132,7 +132,7 @@ namespace TR
 		/// <returns>書き込みに成功したかどうか</returns>
 		public override bool Write<T>(long pos, ref T buf) where T : struct
 		{
-			if (!base.Read(pos, out buf) || MMVA == IntPtr.Zero)
+			if (!base.Write(pos, ref buf) || MMVA == IntPtr.Zero)
 				return false;
 
 			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -162,6 +162,14 @@ namespace TR
 			{
 				Marshal.Copy(iarr, offset, ip_writeTo, count);
 			}
+			else if(buf is double[] darr)
+			{
+				Marshal.Copy(darr, offset, ip_writeTo, count);
+			}
+			else if(buf is float[] farr)
+			{
+				Marshal.Copy(farr, offset, ip_writeTo, count);
+			}
 			else if (buf is bool[] barr)
 			{
 				byte[] ba2w = new byte[count];//SMemに書き込む配列

--- a/TR.SMemIF/SemaphorelessSMemIF.net20.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net20.cs
@@ -55,9 +55,20 @@ namespace TR
 			if (!base.Read(pos, out buf) || MMVA == IntPtr.Zero)
 				return false;
 
-			IntPtr ip_readFrom = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-			buf = (T)Marshal.PtrToStructure(ip_readFrom, typeof(T));
+			_Read(pos, out buf);
 			return true;
+		}
+
+		/// <summary>値の読み込み機能のコア機能</summary>
+		/// <typeparam name="T">型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込んだデータの書き込み先</param>
+		private void _Read<T>(in long pos, out T buf) where T : struct
+		{
+			//読み取り開始位置適用済みのポインタ
+			IntPtr ip_readFrom = new IntPtr(MMVA.ToInt64() + pos);
+
+			buf = (T) Marshal.PtrToStructure(ip_readFrom, typeof(T));
 		}
 
 		/// <summary>SMemから連続的に値を読み取ります</summary>
@@ -117,9 +128,21 @@ namespace TR
 			if (!base.Write(pos, ref buf) || MMVA == IntPtr.Zero)
 				return false;
 
-			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);//読み取り開始位置適用済みのポインタ
-			Marshal.StructureToPtr(buf, ip_writeTo, false);//予め確保してた場所にStructureを書き込む
+			_Write(pos, in buf);
 			return true;
+		}
+
+		/// <summary>値の書き込み機能のコア部分</summary>
+		/// <typeparam name="T">型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		private void _Write<T>(in long pos, in T buf) where T : struct
+		{
+			//読み取り開始位置適用済みのポインタ
+			IntPtr ip_writeTo = new IntPtr(MMVA.ToInt64() + pos);
+
+			//予め確保してた場所にStructureを書き込む
+			Marshal.StructureToPtr(buf, ip_writeTo, false);
 		}
 
 		/// <summary>SMemに連続した値を書き込みます</summary>

--- a/TR.SMemIF/SemaphorelessSMemIF.net40.cs
+++ b/TR.SMemIF/SemaphorelessSMemIF.net40.cs
@@ -1,0 +1,152 @@
+﻿#if NET40_OR_GREATER || NETCOREAPP || NETSTANDARD
+
+using System;
+using System.IO.MemoryMappedFiles;
+
+namespace TR
+{
+	/// <summary>共有メモリにアクセスする際に, セマフォによる排他制御を呼び出し元で行う場合に使用するクラス</summary>
+	public class SemaphorelessSMemIF : SemaphorelessSMemIF_Preprocessing
+	{
+		MemoryMappedFile? MMF = null;
+		MemoryMappedViewAccessor? MMVA = null;
+
+		const long Capacity_Step = 4096;
+
+		/// <summary>インスタンスを初期化します</summary>
+		/// <param name="smem_name">共有メモリ空間の名前</param>
+		/// <param name="capacity">共有メモリ空間のキャパシティ</param>
+		public SemaphorelessSMemIF(string smem_name, long capacity) : base(smem_name, capacity)
+		{
+		}
+
+		/// <summary>共有メモリ空間のキャパシティ</summary>
+		/// <remarks>キャパシティ変更には大きなコストが伴うので注意  (メモリ空間を開き直すため)</remarks>
+		public override long Capacity
+		{
+			get => MMVA?.Capacity ?? 0;
+			set
+			{
+				MMVA?.Dispose();
+				MMF?.Dispose();
+
+				if (value <= 0)
+					throw new ArgumentOutOfRangeException(nameof(value), "Capacity cannot be 0 or less");
+
+				long newCap = (long)Math.Ceiling((float)value / Capacity_Step) * Capacity_Step;
+
+				MMF = MemoryMappedFile.CreateOrOpen(SMemName, newCap);
+
+				//sizeに0を指定すると, 最大サイズで取得することができる
+				//…はずだけど, 0にすると正常に取得できなくてpositionがOutOfRangeだよって言われる
+				MMVA = MMF.CreateViewAccessor(0, newCap);
+			}
+		}
+
+		/// <summary>共有メモリ空間の指定の位置から, 指定の型のデータを読み込む</summary>
+		/// <typeparam name="T">読み込みたい型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み込むデータ</param>
+		/// <returns>読み込みに成功したかどうか  (例外は捕捉されません)</returns>
+		public override bool Read<T>(long pos, out T buf) where T : struct
+		{
+			if (!base.Read(pos, out buf) || MMVA?.CanRead != true)
+				return false;
+
+			MMVA.Read(pos, out buf);
+
+			return true;
+		}
+
+		/// <summary>SMemから連続的に値を読み取ります</summary>
+		/// <typeparam name="T">値の型</typeparam>
+		/// <param name="pos">読み込む位置 [bytes]</param>
+		/// <param name="buf">読み取り結果を格納する配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">読み取りを行う数</param>
+		/// <returns>読み取りに成功したかどうか</returns>
+		public override bool ReadArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.ReadArray(pos, buf, offset, count) || MMVA?.CanRead != true)
+				return false;
+
+			MMVA.ReadArray(pos, buf, offset, count);
+			return true;
+		}
+
+		/// <summary>共有メモリ空間の指定の位置に指定のデータを書き込む</summary>
+		/// <typeparam name="T">データの型</typeparam>
+		/// <param name="pos">書き込む位置 [bytes]</param>
+		/// <param name="buf">書き込むデータ</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool Write<T>(long pos, ref T buf) where T : struct
+		{
+			if (!base.Write(pos, ref buf) || MMVA?.CanWrite != true)
+				return false;
+
+			MMVA.Write(pos, ref buf);
+			return true;
+		}
+
+		/// <summary>SMemに連続した値を書き込みます</summary>
+		/// <typeparam name="T">書き込む値の型</typeparam>
+		/// <param name="pos">書き込みを開始するSMem内の位置 [bytes]</param>
+		/// <param name="buf">SMemに書き込む配列</param>
+		/// <param name="offset">配列内で書き込みを開始する位置</param>
+		/// <param name="count">書き込む要素数</param>
+		/// <returns>書き込みに成功したかどうか</returns>
+		public override bool WriteArray<T>(long pos, T[] buf, int offset, int count) where T : struct
+		{
+			if (!base.WriteArray(pos, buf, offset, count) || MMVA?.CanWrite != true)
+				return false;
+
+			MMVA.WriteArray(pos, buf, offset, count);
+			return true;
+		}
+
+		#region IDisposable Support
+		/// <summary>リソースの解放が完了したかどうか</summary>
+		protected bool disposedValue = false;
+
+		/// <summary>保持しているリソースを解放する</summary>
+		/// <param name="disposing">Managedリソースも解放するかどうか</param>
+		protected virtual void Dispose(bool disposing)
+		{
+			disposedValue = true;
+
+			if (!disposedValue)
+			{
+				if (disposing)
+				{
+					MMVA?.Dispose();
+					MMVA = null;
+					MMF?.Dispose();
+					MMF = null;
+				}
+
+				disposedValue = true;
+			}
+		}
+
+		/// <summary>保持しているリソースを解放する</summary>
+		public override void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+		#endregion
+
+
+		/// <summary>共有メモリ空間を再度開く必要があるかどうかを確認する</summary>
+		/// <param name="needed_capacity">必要なキャパシティ</param>
+		protected override void CheckReOpen(long needed_capacity)
+		{
+			if (Capacity > needed_capacity)
+				return;//保持キャパが要求キャパより大きいなら, 再度開く必要はない
+
+			Capacity = needed_capacity;
+		}
+	}
+}
+#endif

--- a/TR.SMemIF/TR.SMemIF.csproj
+++ b/TR.SMemIF/TR.SMemIF.csproj
@@ -35,5 +35,6 @@ It is recommended to use through TR.SMemCtrler because this library provides onl
 	  <DebugSymbols>true</DebugSymbols>
 	  <DefineConstants Condition="'$(Configuration)'=='Debug'">DEBUG;TRACE</DefineConstants>
 	  <Nullable>enable</Nullable>
+	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 </Project>

--- a/TR.SMemIF/TR.SMemIF.csproj
+++ b/TR.SMemIF/TR.SMemIF.csproj
@@ -34,5 +34,6 @@ It is recommended to use through TR.SMemCtrler because this library provides onl
 	  <DebugType>pdbonly</DebugType>
 	  <DebugSymbols>true</DebugSymbols>
 	  <DefineConstants Condition="'$(Configuration)'=='Debug'">DEBUG;TRACE</DefineConstants>
+	  <Nullable>enable</Nullable>
 	</PropertyGroup>
 </Project>

--- a/TR.SMemIF/TR.SMemIF.csproj
+++ b/TR.SMemIF/TR.SMemIF.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net20;net35;net461;net5.0-windows</TargetFrameworks>
-		<LangVersion>8.0</LangVersion>
+		<LangVersion>9.0</LangVersion>
 		<AssemblyName>TR.SMemIF</AssemblyName>
 		<RootNamespace>TR</RootNamespace>
 		<Version>1.0.0.3</Version>

--- a/TR.SMemIF/TR.SMemIF.csproj
+++ b/TR.SMemIF/TR.SMemIF.csproj
@@ -37,4 +37,8 @@ It is recommended to use through TR.SMemCtrler because this library provides onl
 	  <Nullable>enable</Nullable>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
+	  <PlatformTarget>AnyCPU</PlatformTarget>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
net35では `AccessViolationException 保護されているメモリに読み取りまたは書き込み操作を行おうとしました。他のメモリが壊れていることが考えられます。` とか言われることがあるが, これの解消が非常に面倒そうなため, 一旦完了扱いにする.

net35以前は消極的サポート扱いとし, 4096byte以下のデータの取り扱いのみをサポートする  
実際はそれよりも大きな領域を扱える場合もあったが, 単体で実行しなければならないなど制約があったため, 不具合が残っているものとして扱う